### PR TITLE
add `peerDependencies` to `@yarn-tool/resolve-package`

### DIFF
--- a/packages/@yarn-tool/resolve-package/package.json
+++ b/packages/@yarn-tool/resolve-package/package.json
@@ -58,6 +58,9 @@
     "tslib": "^2.3.1",
     "upath2": "^3.1.12"
   },
+  "peerDependencies": {
+    "@types/node": "*"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Resolves this `yarn install` warning:

```
➤ YN0002: │ @yarn-tool/resolve-package@npm:1.0.41 doesn't provide @types/node (p44ed6), requested by upath2
```

I presume the Node type version should be handled by the consumer, not this package, since the Node version can vary widely. Hence version `*`.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>