### PR TITLE
Use `@types` packages as dev dependency

### DIFF
--- a/packages/@yarn-tool/resolve-package/package.json
+++ b/packages/@yarn-tool/resolve-package/package.json
@@ -53,12 +53,12 @@
     "tsc:esm": "tsc -p tsconfig.esm.json"
   },
   "dependencies": {
-    "@ts-type/package-dts": "^1.0.58",
     "pkg-dir": "< 6 >= 5",
     "tslib": "^2.3.1",
     "upath2": "^3.1.12"
   },
-  "peerDependencies": {
+  "devDependencies": {
+    "@ts-type/package-dts": "^1.0.58",
     "@types/node": "*"
   },
   "publishConfig": {


### PR DESCRIPTION
PR #2 added `@types/node` as peerDependency, but this gives warnings when installing resolve-package:

```
warning "rollup-plugin-typescript2 > @yarn-tool/resolve-package@1.0.42" has unmet peer dependency "@types/node@*".
```

According to the docs https://github.com/DefinitelyTyped/DefinitelyTyped#npm these dependencies should be added as devDependencies, because they are only needed during build time

Edit: I had a look, and `@ts-type/package-dts` looks like it is also _only_ TS types, so it is also not needed during runtime, only build time, therefore I also moved it to devDependencies (will get rid of the warning: warning "rollup-plugin-typescript2 > @yarn-tool/resolve-package > @ts-type/package-dts@1.0.58" has unmet peer dependency "@types/bluebird@*".)

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>